### PR TITLE
README: Fix repo URL for west init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ source and all Zephyr modules will be cloned. You can do that by running:
 
 ```shell
 # initialize spinner workspace
-west init -m git@github.com:teslabs/spinner --mr main spinner
+west init -m https://github.com/teslabs/spinner --mr main spinner
 # update modules
 cd spinner
 west update


### PR DESCRIPTION
The original command failed (sorry for the German error message):
```
$ west init -m git@github.com:teslabs/spinner --mr main spinner
=== Initializing in /home/martin/LibreSolar/2_Development/05_Firmware/spinner
--- Cloning manifest repository from git@github.com:teslabs/spinner, rev. main
Leeres Git-Repository in /home/martin/LibreSolar/2_Development/05_Firmware/spinner/.west/manifest-tmp/.git/ initialisiert
git@github.com: Permission denied (publickey).
fatal: Konnte nicht vom Remote-Repository lesen.

Bitte stellen Sie sicher, dass die korrekten Zugriffsberechtigungen bestehen
und das Repository existiert.
FATAL ERROR: command exited with status 128: git fetch origin --tags -- main 'refs/heads/*:refs/remotes/origin/*'
```